### PR TITLE
Fix EXC_BAD_ACCESS crash on SSL_CTX_new on iOS.

### DIFF
--- a/src/SSLSocket.c
+++ b/src/SSLSocket.c
@@ -550,7 +550,8 @@ int SSLSocket_createContext(networkHandles* net, MQTTClient_SSLOptions* opts)
 	FUNC_ENTRY;
 	if (net->ctx == NULL)
 	{
-#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
+        
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(OPENSSL_SYS_iOS))
 		net->ctx = SSL_CTX_new(TLS_client_method());
 #else
 		int sslVersion = MQTT_SSL_VERSION_DEFAULT;
@@ -562,7 +563,11 @@ int SSLSocket_createContext(networkHandles* net, MQTTClient_SSLOptions* opts)
 		switch (sslVersion)
 		{
 		case MQTT_SSL_VERSION_DEFAULT:
+#if defined(OPENSSL_SYS_iOS)
+            net->ctx = SSL_CTX_new(TLSv1_2_client_method());
+#else
 			net->ctx = SSL_CTX_new(SSLv23_client_method()); /* SSLv23 for compatibility with SSLv2, SSLv3 and TLSv1 */
+#endif
 			break;
 #if defined(SSL_OP_NO_TLSv1) && !defined(OPENSSL_NO_TLS1)
 		case MQTT_SSL_VERSION_TLS_1_0:


### PR DESCRIPTION
SSLv23_client_method() is not supported on iOS and create crash.

Change-Id: I03c8cd4841bbd6b40331090af512d06d5e6b3a2d


Thank you for your interest in this project managed by the Eclipse Foundation.

The guidelines for contributions can be found in the CONTRIBUTING.md file.

At a minimum, you must sign the Eclipse ECA, and sign off each commit.  

To complete and submit a ECA, log into the Eclipse projects forge 
You will need to create an account with the Eclipse Foundation if you have not already done so.
Be sure to use the same email address when you register for the account that you intend to use when you commit to Git.
Go to https://accounts.eclipse.org/user/eca to sign the Eclipse ECA.


